### PR TITLE
Add backlog parameter to listen().

### DIFF
--- a/c_src/src/tlsAcceptor.cpp
+++ b/c_src/src/tlsAcceptor.cpp
@@ -15,13 +15,16 @@ namespace etls {
 
 TLSAcceptor::TLSAcceptor(TLSApplication &app, const unsigned short port,
     const std::string &certPath, const std::string &keyPath,
-    std::string rfc2818Hostname)
+    std::string rfc2818Hostname, const std::size_t backlog)
     : detail::WithSSLContext{asio::ssl::context::tlsv12_server, certPath,
           keyPath, std::move(rfc2818Hostname)}
     , m_app{app}
     , m_ioService{app.ioService()}
-    , m_acceptor{m_ioService, {asio::ip::tcp::v4(), port}}
+    , m_acceptor{m_ioService, asio::ip::tcp::v4()}
 {
+    m_acceptor.set_option(asio::socket_base::reuse_address{true});
+    m_acceptor.bind({asio::ip::tcp::v4(), port});
+    m_acceptor.listen(backlog);
 }
 
 void TLSAcceptor::acceptAsync(Ptr self, Callback<TLSSocket::Ptr> callback)

--- a/c_src/src/tlsAcceptor.hpp
+++ b/c_src/src/tlsAcceptor.hpp
@@ -45,10 +45,13 @@ public:
      * @param certPath Path to a PEM certificate file to use for the TLS
      * connection.
      * @param keyPath Path to a PEM keyfile to use for the TLS connection.
+     * @param backlog The number of connections that may be pending on the
+     * socket.
      */
     TLSAcceptor(TLSApplication &m_app, const unsigned short port,
         const std::string &certPath, const std::string &keyPath,
-        std::string rfc2818Hostname = "");
+        std::string rfc2818Hostname = "",
+        const std::size_t backlog = asio::socket_base::max_connections);
 
     /**
      * Asynchronously accepts a single pending connection.

--- a/c_src/src/wrapper.cpp
+++ b/c_src/src/wrapper.cpp
@@ -13,6 +13,7 @@
 #include "tlsSocket.hpp"
 
 #include <asio/error.hpp>
+#include <asio/socket_base.hpp>
 
 #include <algorithm>
 #include <memory>
@@ -250,10 +251,11 @@ ERL_NIF_TERM listen(ErlNifEnv *env, Env /*localEnv*/, ErlNifPid /*pid*/,
     int port, std::string certPath, std::string keyPath, std::string verifyMode,
     bool failIfNoPeerCert, bool verifyClientOnce, std::string rfc2818Hostname,
     std::vector<std::string> CAs, std::vector<std::string> CRLs,
-    std::vector<std::string> chain)
+    std::vector<std::string> chain, int backlog)
 {
+    backlog = backlog == -1 ? asio::socket_base::max_connections : backlog;
     auto acceptor = std::make_shared<one::etls::TLSAcceptor>(
-        app, port, certPath, keyPath, std::move(rfc2818Hostname));
+        app, port, certPath, keyPath, std::move(rfc2818Hostname), backlog);
 
     setTLSOptions(*acceptor, verifyMode, failIfNoPeerCert, verifyClientOnce,
         std::move(CAs), std::move(CRLs), std::move(chain));
@@ -521,7 +523,7 @@ static ERL_NIF_TERM shutdown_nif(
 }
 
 static ErlNifFunc nif_funcs[] = {{"connect", 12, connect_nif},
-    {"send", 2, send_nif}, {"recv", 2, recv_nif}, {"listen", 10, listen_nif},
+    {"send", 2, send_nif}, {"recv", 2, recv_nif}, {"listen", 11, listen_nif},
     {"accept", 2, accept_nif}, {"handshake", 2, handshake_nif},
     {"peername", 2, peername_nif}, {"sockname", 2, sockname_nif},
     {"acceptor_sockname", 2, acceptor_sockname_nif}, {"close", 2, close_nif},

--- a/src/etls_nif.erl
+++ b/src/etls_nif.erl
@@ -16,7 +16,7 @@
 -on_load(init/0).
 
 %% API
--export([connect/12, send/2, recv/2, listen/10, accept/2, handshake/2,
+-export([connect/12, send/2, recv/2, listen/11, accept/2, handshake/2,
     peername/2, sockname/2, acceptor_sockname/2, close/2,
     certificate_chain/1, shutdown/3]).
 
@@ -81,11 +81,12 @@ recv(_Sock, _Size) ->
 -spec listen(Port :: inet:port_number(), CertPath :: str(), KeyPath :: str(),
     VerifyType :: str(), FailIfNoPeerCert :: boolean(),
     VerifyClientOnce :: boolean(), RFC2818Hostname :: str(),
-    CAs :: [binary()], CRLs :: [binary()], Chain :: [binary()]) ->
+    CAs :: [binary()], CRLs :: [binary()], Chain :: [binary()],
+    Backlog :: non_neg_integer() | -1) ->
     {ok, Acceptor :: acceptor()} |
     {error, Reason :: atom()}.
 listen(_Port, _CertPath, _KeyPath, _VerifyType, _FailIfNoPeerCert,
-    _VerifyClientOnce, _RFC2818Hostname, _CAs, _CRLs, _Chain) ->
+    _VerifyClientOnce, _RFC2818Hostname, _CAs, _CRLs, _Chain, _Backlog) ->
     erlang:nif_error(etls_nif_not_loaded).
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
No test added because observable behaviour depends on system settings,
e.g. on Linux the tests passed only after tcp_abort_on_overflow was
set to 1 via /proc.

Fixes #7